### PR TITLE
:rocket: Feature/nflow

### DIFF
--- a/feature-extraction-tool/src/args.rs
+++ b/feature-extraction-tool/src/args.rs
@@ -38,10 +38,15 @@ pub enum Commands {
 pub enum FlowType {
     /// A basic flow that stores the basic features of a flow.
     BasicFlow,
+
     /// Represents the CIC Flow, giving 83 features.
     CicFlow,
+
     /// Represents the CIDDS Flow, giving 10 features.
     CiddsFlow,
+
+    /// Represents a nfstream inspired flow, giving 69 features.
+    NfFlow,
 }
 
 #[derive(clap::ValueEnum, Clone, Debug)]

--- a/feature-extraction-tool/src/flows/basic_flow.rs
+++ b/feature-extraction-tool/src/flows/basic_flow.rs
@@ -11,9 +11,9 @@ pub struct BasicFlow {
     /// The unique identifier of the flow.
     pub flow_id: String,
     /// The destination IP address of the flow.
-    pub ipv4_destination: IpAddr,
+    pub ip_destination: IpAddr,
     /// The source IP address of the flow.
-    pub ipv4_source: IpAddr,
+    pub ip_source: IpAddr,
     /// The destination port of the flow.
     pub port_destination: u16,
     /// The source port of the flow.
@@ -67,16 +67,16 @@ pub struct BasicFlow {
 impl Flow for BasicFlow {
     fn new(
         flow_id: String,
-        ipv4_source: IpAddr,
+        ip_source: IpAddr,
         port_source: u16,
-        ipv4_destination: IpAddr,
+        ip_destination: IpAddr,
         port_destination: u16,
         protocol: u8,
     ) -> Self {
         BasicFlow {
             flow_id,
-            ipv4_destination,
-            ipv4_source,
+            ip_destination,
+            ip_source,
             port_destination,
             port_source,
             protocol,
@@ -146,9 +146,9 @@ impl Flow for BasicFlow {
             "{},{},{},{},{},{},{},{},{},{},{},{},{},\
         {},{},{},{},{},{},{},{},{},{},{},{},{},{}",
             self.flow_id,
-            self.ipv4_source,
+            self.ip_source,
             self.port_source,
-            self.ipv4_destination,
+            self.ip_destination,
             self.port_destination,
             self.protocol,
             self.first_timestamp,

--- a/feature-extraction-tool/src/flows/cic_flow.rs
+++ b/feature-extraction-tool/src/flows/cic_flow.rs
@@ -45,7 +45,7 @@ pub struct CicFlow {
     /// The number of data packets in the forward flow with more than one byte of data.
     pub fwd_act_data_pkt: u32,
     /// The minimum header length of the forward flow.
-    pub fwd_header_len_min: u32,
+    fwd_header_len_min: u32,
     /// The timestamp of the last packet in the forward flow.
     pub fwd_last_timestamp: Option<Instant>,
     /// The total length of packets in the forward flow.

--- a/feature-extraction-tool/src/flows/cic_flow.rs
+++ b/feature-extraction-tool/src/flows/cic_flow.rs
@@ -13,63 +13,63 @@ pub struct CicFlow {
     /// The basic flow information.
     pub basic_flow: BasicFlow,
     /// The timestamp of the last packet in the subflow.
-    sf_last_packet_timestamp: Option<Instant>,
+    pub sf_last_packet_timestamp: Option<Instant>,
     /// The number of subflows.
-    sf_count: u32,
+    pub sf_count: u32,
     /// The timestamp of the start of an active period.
-    start_active: Instant,
+    pub start_active: Instant,
     /// The timestamp of the end of an active period.
-    end_active: Instant,
+    pub end_active: Instant,
     /// The number of active periods.
-    active_count: u32,
+    pub active_count: u32,
     /// The mean of active periods.
-    active_mean: f64,
+    pub active_mean: f64,
     /// The standard deviation of active periods.
-    active_std: f64,
+    pub active_std: f64,
     /// The maximum active period.
-    active_max: f64,
+    pub active_max: f64,
     /// The minimum active period.
     active_min: f64,
     /// The number of idle periods.
-    idle_count: u32,
+    pub idle_count: u32,
     /// The mean of idle periods.
-    idle_mean: f64,
+    pub idle_mean: f64,
     /// The standard deviation of idle periods.
-    idle_std: f64,
+    pub idle_std: f64,
     /// The maximum idle period.
-    idle_max: f64,
+    pub idle_max: f64,
     /// The minimum idle period.
     idle_min: f64,
     /// The initial window size of the forward flow.
-    fwd_init_win_bytes: u16,
+    pub fwd_init_win_bytes: u16,
     /// The number of data packets in the forward flow with more than one byte of data.
-    fwd_act_data_pkt: u32,
+    pub fwd_act_data_pkt: u32,
     /// The minimum header length of the forward flow.
-    fwd_header_len_min: u32,
+    pub fwd_header_len_min: u32,
     /// The timestamp of the last packet in the forward flow.
-    fwd_last_timestamp: Option<Instant>,
+    pub fwd_last_timestamp: Option<Instant>,
     /// The total length of packets in the forward flow.
-    fwd_pkt_len_tot: u32,
+    pub fwd_pkt_len_tot: u32,
     /// The maximum length of packets in the forward flow.
-    fwd_pkt_len_max: u32,
+    pub fwd_pkt_len_max: u32,
     /// The minimum length of packets in the forward flow.
     fwd_pkt_len_min: u32,
     /// The mean length of packets in the forward flow.
-    fwd_pkt_len_mean: f32,
+    pub fwd_pkt_len_mean: f32,
     /// The standard deviation of the length of packets in the forward flow.
-    fwd_pkt_len_std: f32,
+    pub fwd_pkt_len_std: f32,
     /// The total inter-arrival time of packets in the forward flow.
-    fwd_iat_total: f64,
+    pub fwd_iat_total: f64,
     /// The mean inter-arrival time of packets in the forward flow.
-    fwd_iat_mean: f64,
+    pub fwd_iat_mean: f64,
     /// The standard deviation of the inter-arrival time of packets in the forward flow.
-    fwd_iat_std: f64,
+    pub fwd_iat_std: f64,
     /// The maximum inter-arrival time of packets in the forward flow.
-    fwd_iat_max: f64,
+    pub fwd_iat_max: f64,
     /// The minimum inter-arrival time of packets in the forward flow.
     fwd_iat_min: f64,
     /// The total header length of the forward flow.
-    fwd_header_length: u32,
+    pub fwd_header_length: u32,
     /// The total duration of bulk packets in the forward flow.
     fwd_bulk_duration: f64,
     /// The number of bulk packets in the forward flow.
@@ -85,33 +85,33 @@ pub struct CicFlow {
     /// Helper variable for bulk size.
     fwd_bulk_size_help: u32,
     /// The timestamp of the last bulk packet in the forward flow.
-    fwd_last_bulk_timestamp: Option<Instant>,
+    pub fwd_last_bulk_timestamp: Option<Instant>,
     /// The initial window size of the backward flow.
-    bwd_init_win_bytes: u16,
+    pub bwd_init_win_bytes: u16,
     /// The timestamp of the last packet in the backward flow.
-    bwd_last_timestamp: Option<Instant>,
+    pub bwd_last_timestamp: Option<Instant>,
     /// The total length of packets in the backward flow.
-    bwd_pkt_len_tot: u32,
+    pub bwd_pkt_len_tot: u32,
     /// The maximum length of packets in the backward flow.
-    bwd_pkt_len_max: u32,
+    pub bwd_pkt_len_max: u32,
     /// The minimum length of packets in the backward flow.
     bwd_pkt_len_min: u32,
     /// The mean length of packets in the backward flow.
-    bwd_pkt_len_mean: f32,
+    pub bwd_pkt_len_mean: f32,
     /// The standard deviation of the length of packets in the backward flow.
-    bwd_pkt_len_std: f32,
+    pub bwd_pkt_len_std: f32,
     /// The total inter-arrival time of packets in the backward flow.
-    bwd_iat_total: f64,
+    pub bwd_iat_total: f64,
     /// The mean inter-arrival time of packets in the backward flow.
-    bwd_iat_mean: f64,
+    pub bwd_iat_mean: f64,
     /// The standard deviation of the inter-arrival time of packets in the backward flow.
-    bwd_iat_std: f64,
+    pub bwd_iat_std: f64,
     /// The maximum inter-arrival time of packets in the backward flow.
-    bwd_iat_max: f64,
+    pub bwd_iat_max: f64,
     /// The minimum inter-arrival time of packets in the backward flow.
     bwd_iat_min: f64,
     /// The total header length of the backward flow.
-    bwd_header_length: u32,
+    pub bwd_header_length: u32,
     /// The total duration of bulk packets in the backward flow.
     bwd_bulk_duration: f64,
     /// The number of bulk packets in the backward flow.
@@ -544,7 +544,7 @@ impl CicFlow {
     /// # Returns
     ///
     /// Pooled standard deviation of the flow's IATs.
-    fn get_flow_iat_std(&self) -> f64 {
+    pub fn get_flow_iat_std(&self) -> f64 {
         if self.basic_flow.fwd_packet_count < 1
             || self.basic_flow.bwd_packet_count < 1
             || self.basic_flow.fwd_packet_count + self.basic_flow.bwd_packet_count < 3
@@ -569,7 +569,7 @@ impl CicFlow {
     /// # Returns
     ///
     /// Mean inter-arrival time of the flow.
-    fn get_flow_iat_mean(&self) -> f64 {
+    pub fn get_flow_iat_mean(&self) -> f64 {
         (self.fwd_iat_mean * self.basic_flow.fwd_packet_count as f64
             + self.bwd_iat_mean * self.basic_flow.bwd_packet_count as f64)
             / (self.basic_flow.fwd_packet_count + self.basic_flow.bwd_packet_count) as f64
@@ -582,7 +582,7 @@ impl CicFlow {
     /// # Returns
     ///
     /// Maximum inter-arrival time observed in the flow.
-    fn get_flow_iat_max(&self) -> f64 {
+    pub fn get_flow_iat_max(&self) -> f64 {
         if self.fwd_iat_max > self.bwd_iat_max {
             return self.fwd_iat_max;
         }
@@ -596,7 +596,7 @@ impl CicFlow {
     /// # Returns
     ///
     /// Minimum inter-arrival time observed in the flow or 0 if not set.
-    fn get_flow_iat_min(&self) -> f64 {
+    pub fn get_flow_iat_min(&self) -> f64 {
         if self.fwd_iat_min < self.bwd_iat_min {
             if self.fwd_iat_min == f64::MAX {
                 return 0.0;
@@ -617,7 +617,7 @@ impl CicFlow {
     /// # Returns
     ///
     /// The minimum IAT observed in the forward flow or 0 if not set.
-    fn get_fwd_iat_min(&self) -> f64 {
+    pub fn get_fwd_iat_min(&self) -> f64 {
         if self.fwd_iat_min == f64::MAX {
             return 0.0;
         }
@@ -631,7 +631,7 @@ impl CicFlow {
     /// # Returns
     ///
     /// The minimum IAT observed in the backward flow or 0 if not set.
-    fn get_bwd_iat_min(&self) -> f64 {
+    pub fn get_bwd_iat_min(&self) -> f64 {
         if self.bwd_iat_min == f64::MAX {
             return 0.0;
         }
@@ -646,7 +646,7 @@ impl CicFlow {
     /// # Returns
     ///
     /// Minimum packet length in the flow, or 0 if not set.
-    fn get_flow_packet_length_min(&self) -> u32 {
+    pub fn get_flow_packet_length_min(&self) -> u32 {
         if self.fwd_pkt_len_min < self.bwd_pkt_len_min {
             if self.fwd_pkt_len_min == u32::MAX {
                 return 0;
@@ -667,7 +667,7 @@ impl CicFlow {
     /// # Returns
     ///
     /// Maximum packet length in the flow.
-    fn get_flow_packet_length_max(&self) -> u32 {
+    pub fn get_flow_packet_length_max(&self) -> u32 {
         if self.fwd_pkt_len_max > self.bwd_pkt_len_max {
             return self.fwd_pkt_len_max;
         }
@@ -682,7 +682,7 @@ impl CicFlow {
     /// # Returns
     ///
     /// Minimum forward packet length, or 0 if not set.
-    fn get_fwd_packet_length_min(&self) -> u32 {
+    pub fn get_fwd_packet_length_min(&self) -> u32 {
         if self.fwd_pkt_len_min == u32::MAX {
             return 0;
         }
@@ -697,7 +697,7 @@ impl CicFlow {
     /// # Returns
     ///
     /// Minimum backward packet length, or 0 if not set.
-    fn get_bwd_packet_length_min(&self) -> u32 {
+    pub fn get_bwd_packet_length_min(&self) -> u32 {
         if self.bwd_pkt_len_min == u32::MAX {
             return 0;
         }
@@ -711,7 +711,7 @@ impl CicFlow {
     /// # Returns
     ///
     /// Mean packet length of the flow.
-    fn get_flow_packet_length_mean(&self) -> f32 {
+    pub fn get_flow_packet_length_mean(&self) -> f32 {
         (self.fwd_pkt_len_mean * self.basic_flow.fwd_packet_count as f32
             + self.bwd_pkt_len_mean * self.basic_flow.bwd_packet_count as f32) as f32
             / (self.basic_flow.fwd_packet_count + self.basic_flow.bwd_packet_count) as f32
@@ -748,7 +748,7 @@ impl CicFlow {
     /// # Returns
     ///
     /// Standard deviation of the flow's packet lengths.
-    fn get_flow_packet_length_std(&self) -> f64 {
+    pub fn get_flow_packet_length_std(&self) -> f64 {
         self.get_flow_packet_length_variance().sqrt()
     }
 
@@ -1198,9 +1198,9 @@ impl Flow for CicFlow {
             {},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},\
             {},{},{},{}",
             self.basic_flow.flow_id,
-            self.basic_flow.ipv4_source,
+            self.basic_flow.ip_source,
             self.basic_flow.port_source,
-            self.basic_flow.ipv4_destination,
+            self.basic_flow.ip_destination,
             self.basic_flow.port_destination,
             self.basic_flow.protocol,
             self.basic_flow.first_timestamp,

--- a/feature-extraction-tool/src/flows/cidds_flow.rs
+++ b/feature-extraction-tool/src/flows/cidds_flow.rs
@@ -121,9 +121,9 @@ impl Flow for CiddsFlow {
             } else {
                 "OTHER"
             },
-            self.basic_flow.ipv4_source,
+            self.basic_flow.ip_source,
             self.basic_flow.port_source,
-            self.basic_flow.ipv4_destination,
+            self.basic_flow.ip_destination,
             self.basic_flow.port_destination,
             self.basic_flow.fwd_packet_count + self.basic_flow.bwd_packet_count,
             self.bytes,

--- a/feature-extraction-tool/src/flows/mod.rs
+++ b/feature-extraction-tool/src/flows/mod.rs
@@ -2,3 +2,4 @@ pub mod basic_flow;
 pub mod cic_flow;
 pub mod cidds_flow;
 pub mod flow;
+pub mod nf_flow;

--- a/feature-extraction-tool/src/flows/nf_flow.rs
+++ b/feature-extraction-tool/src/flows/nf_flow.rs
@@ -1,0 +1,133 @@
+use std::{
+    net::IpAddr,
+    time::{Instant, SystemTime, UNIX_EPOCH},
+};
+
+use crate::utils::utils::BasicFeatures;
+
+use super::{cic_flow::CicFlow, flow::Flow};
+
+pub struct NfFlow {
+    pub cic_flow: CicFlow,
+    pub first_timestamp: SystemTime,
+    pub last_timestamp: SystemTime,
+    pub fwd_first_timestamp: SystemTime,
+    pub fwd_last_timestamp: SystemTime,
+    pub bwd_first_timestamp: SystemTime,
+    pub bwd_last_timestamp: SystemTime,
+}
+
+impl Flow for NfFlow {
+    fn new(
+        flow_id: String,
+        ipv4_source: IpAddr,
+        port_source: u16,
+        ipv4_destination: IpAddr,
+        port_destination: u16,
+        protocol: u8,
+    ) -> Self {
+        NfFlow {
+            cic_flow: CicFlow::new(
+                flow_id,
+                ipv4_source,
+                port_source,
+                ipv4_destination,
+                port_destination,
+                protocol,
+            ),
+            first_timestamp: SystemTime::now(),
+            last_timestamp: SystemTime::now(),
+            fwd_first_timestamp: SystemTime::now(),
+            fwd_last_timestamp: SystemTime::now(),
+            bwd_first_timestamp: SystemTime::now(),
+            bwd_last_timestamp: SystemTime::now(),
+        }
+    }
+
+    fn update_flow(
+        &mut self,
+        packet: &BasicFeatures,
+        timestamp: &Instant,
+        fwd: bool,
+    ) -> Option<String> {
+        self.cic_flow.update_flow(packet, timestamp, fwd)
+    }
+
+    fn dump(&self) -> String {
+        format!("{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}",
+            self.cic_flow.basic_flow.flow_id,
+            self.cic_flow.basic_flow.ip_source,
+            self.cic_flow.basic_flow.port_source,
+            self.cic_flow.basic_flow.ip_destination,
+            self.cic_flow.basic_flow.port_destination,
+            self.cic_flow.basic_flow.protocol,
+            self.first_timestamp.duration_since(UNIX_EPOCH).unwrap().as_millis(),
+            self.last_timestamp.duration_since(UNIX_EPOCH).unwrap().as_millis(),
+            self.last_timestamp.duration_since(UNIX_EPOCH).unwrap().as_millis() - self.first_timestamp.duration_since(UNIX_EPOCH).unwrap().as_millis(),
+            self.cic_flow.basic_flow.fwd_packet_count + self.cic_flow.basic_flow.bwd_packet_count,
+            self.cic_flow.fwd_pkt_len_tot + self.cic_flow.bwd_pkt_len_tot,
+            self.fwd_first_timestamp.duration_since(UNIX_EPOCH).unwrap().as_millis(),
+            self.fwd_last_timestamp.duration_since(UNIX_EPOCH).unwrap().as_millis(),
+            self.fwd_last_timestamp.duration_since(UNIX_EPOCH).unwrap().as_millis() - self.fwd_first_timestamp.duration_since(UNIX_EPOCH).unwrap().as_millis(),
+            self.cic_flow.basic_flow.fwd_packet_count,
+            self.cic_flow.fwd_pkt_len_tot,
+            self.bwd_first_timestamp.duration_since(UNIX_EPOCH).unwrap().as_millis(),
+            self.bwd_last_timestamp.duration_since(UNIX_EPOCH).unwrap().as_millis(),
+            self.bwd_last_timestamp.duration_since(UNIX_EPOCH).unwrap().as_millis() - self.bwd_first_timestamp.duration_since(UNIX_EPOCH).unwrap().as_millis(),
+            self.cic_flow.basic_flow.bwd_packet_count,
+            self.cic_flow.bwd_pkt_len_tot,
+            self.cic_flow.get_flow_packet_length_min(),
+            self.cic_flow.get_flow_packet_length_mean(),
+            self.cic_flow.get_flow_packet_length_std(),
+            self.cic_flow.get_flow_packet_length_max(),
+            self.cic_flow.get_fwd_packet_length_min(),
+            self.cic_flow.fwd_pkt_len_mean,
+            self.cic_flow.fwd_pkt_len_std,
+            self.cic_flow.fwd_pkt_len_max,
+            self.cic_flow.get_bwd_packet_length_min(),
+            self.cic_flow.bwd_pkt_len_mean,
+            self.cic_flow.bwd_pkt_len_std,
+            self.cic_flow.bwd_pkt_len_max,
+            self.cic_flow.get_flow_iat_min() / 1000.0,
+            self.cic_flow.get_flow_iat_mean() / 1000.0,
+            self.cic_flow.get_flow_iat_std() / 1000.0,
+            self.cic_flow.get_flow_iat_max() / 1000.0,
+            self.cic_flow.get_fwd_iat_min() / 1000.0,
+            self.cic_flow.fwd_iat_mean / 1000.0,
+            self.cic_flow.fwd_iat_std / 1000.0,
+            self.cic_flow.fwd_iat_max / 1000.0,
+            self.cic_flow.get_bwd_iat_min() / 1000.0,
+            self.cic_flow.bwd_iat_mean / 1000.0,
+            self.cic_flow.bwd_iat_std / 1000.0,
+            self.cic_flow.bwd_iat_max / 1000.0,
+            self.cic_flow.basic_flow.fwd_syn_flag_count + self.cic_flow.basic_flow.bwd_syn_flag_count,
+            self.cic_flow.basic_flow.fwd_cwe_flag_count + self.cic_flow.basic_flow.bwd_cwe_flag_count,
+            self.cic_flow.basic_flow.fwd_ece_flag_count + self.cic_flow.basic_flow.bwd_ece_flag_count,
+            self.cic_flow.basic_flow.fwd_urg_flag_count + self.cic_flow.basic_flow.bwd_urg_flag_count,
+            self.cic_flow.basic_flow.fwd_ack_flag_count + self.cic_flow.basic_flow.bwd_ack_flag_count,
+            self.cic_flow.basic_flow.fwd_psh_flag_count + self.cic_flow.basic_flow.bwd_psh_flag_count,
+            self.cic_flow.basic_flow.fwd_rst_flag_count + self.cic_flow.basic_flow.bwd_rst_flag_count,
+            self.cic_flow.basic_flow.fwd_fin_flag_count + self.cic_flow.basic_flow.bwd_fin_flag_count,
+            self.cic_flow.basic_flow.fwd_syn_flag_count,
+            self.cic_flow.basic_flow.fwd_cwe_flag_count,
+            self.cic_flow.basic_flow.fwd_ece_flag_count,
+            self.cic_flow.basic_flow.fwd_urg_flag_count,
+            self.cic_flow.basic_flow.fwd_ack_flag_count,
+            self.cic_flow.basic_flow.fwd_psh_flag_count,
+            self.cic_flow.basic_flow.fwd_rst_flag_count,
+            self.cic_flow.basic_flow.fwd_fin_flag_count,
+            self.cic_flow.basic_flow.bwd_syn_flag_count,
+            self.cic_flow.basic_flow.bwd_cwe_flag_count,
+            self.cic_flow.basic_flow.bwd_ece_flag_count,
+            self.cic_flow.basic_flow.bwd_urg_flag_count,
+            self.cic_flow.basic_flow.bwd_ack_flag_count,
+            self.cic_flow.basic_flow.bwd_psh_flag_count,
+            self.cic_flow.basic_flow.bwd_rst_flag_count,
+            self.cic_flow.basic_flow.bwd_fin_flag_count,
+        )
+    }
+
+    fn get_first_timestamp(&self) -> chrono::prelude::DateTime<chrono::prelude::Utc> {
+        self.cic_flow.get_first_timestamp()
+    }
+}

--- a/feature-extraction-tool/src/flows/nf_flow.rs
+++ b/feature-extraction-tool/src/flows/nf_flow.rs
@@ -50,7 +50,18 @@ impl Flow for NfFlow {
         timestamp: &Instant,
         fwd: bool,
     ) -> Option<String> {
-        self.cic_flow.update_flow(packet, timestamp, fwd)
+        if fwd {
+            self.fwd_last_timestamp = SystemTime::now();
+        } else {
+            self.bwd_last_timestamp = SystemTime::now();
+        }
+
+        let end = self.cic_flow.update_flow(packet, timestamp, fwd);
+        if end.is_some() {
+            return Some(self.dump());
+        }
+
+        None
     }
 
     fn dump(&self) -> String {

--- a/feature-extraction-tool/src/main.rs
+++ b/feature-extraction-tool/src/main.rs
@@ -24,7 +24,7 @@ use clap::Parser;
 use common::{BasicFeaturesIpv4, BasicFeaturesIpv6};
 use core::panic;
 use dashmap::DashMap;
-use flows::{basic_flow::BasicFlow, cidds_flow::CiddsFlow, flow::Flow};
+use flows::{basic_flow::BasicFlow, cidds_flow::CiddsFlow, flow::Flow, nf_flow::NfFlow};
 use log::info;
 use std::{
     net::{Ipv4Addr, Ipv6Addr},
@@ -70,6 +70,12 @@ async fn main() {
                 FlowType::CiddsFlow => {
                     if let Err(err) =
                         handle_realtime::<CiddsFlow>(interface, interval, lifespan).await
+                    {
+                        eprintln!("Error: {:?}", err);
+                    }
+                }
+                FlowType::NfFlow => {
+                    if let Err(err) = handle_realtime::<NfFlow>(interface, interval, lifespan).await
                     {
                         eprintln!("Error: {:?}", err);
                     }


### PR DESCRIPTION
Added a flow heavily inspired by the nfstream tool.
Changed the ipv4 variable names to general names, because they can also contain ipv6 addresses.