### PR TITLE
:bug: Fix interval seen as output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This tool is designed for robust and efficient feature extraction in network int
 ### Real-Time Traffic Capture:
 - **To Run/Build**:
   ```bash
-  RUST_LOG=info cargo xtask run -- realtime <interface> <flow_type> <flow_lifetime_sec> <output_method> [output_path] [dump_interval_sec]
+  RUST_LOG=info cargo xtask run -- realtime <interface> <flow_type> <flow_lifetime_sec> <output_method> [output_path] --interval [dump_interval_sec]
   ```
 - **Command Help**:
   ```bash

--- a/feature-extraction-tool/src/args.rs
+++ b/feature-extraction-tool/src/args.rs
@@ -29,6 +29,7 @@ pub enum Commands {
         export_method: Output,
 
         /// The print interval for open flows in seconds, needs to be smaller than the flow maximum lifespan
+        #[clap(long)]
         interval: Option<u64>,
     },
 


### PR DESCRIPTION
Fixed the problem with the interval not working when method print was selected.

closes #28 